### PR TITLE
Fix check percentage exists

### DIFF
--- a/autoload/lightline_lsp_progress.vim
+++ b/autoload/lightline_lsp_progress.vim
@@ -7,7 +7,7 @@ function! lightline_lsp_progress#progress() abort
 
     " show only most new progress
     let s:lsp_progress = s:lsp_progress[0]
-    if s:lsp_progress['message'] != '' && s:lsp_progress['percentage'] != 100
+    if s:lsp_progress['message'] != '' && has_key(s:lsp_progress, 'percentage') && s:lsp_progress['percentage'] != 100
       let percent = ''
       if s:lsp_progress['percentage'] >= 0
         let percent = ' ' . string(s:lsp_progress['percentage']) . '%'


### PR DESCRIPTION
Hi, first of all thank you for making great feature to vim-lsp and lightline.

I've got error when open rust file with rust-analyzer.
```
Error detected while processing function lightline_lsp_progress#progress:
line    8:
E716: Key not present in Dictionary: percentage
E15: Invalid expression: s:lsp_progress['message'] != '' && s:lsp_progress['perc
entage'] != 100
E716: Key not present in Dictionary: percentage
E15: Invalid expression: s:lsp_progress['message'] != '' && s:lsp_progress['perc
entage'] != 100
```

https://user-images.githubusercontent.com/56591/107960301-cd741f00-6fe7-11eb-9661-b87af0f910b7.mp4

Please check this and include 🙏 